### PR TITLE
Allow initialization of hooks when stepping via `update!`

### DIFF
--- a/src/simulator.jl
+++ b/src/simulator.jl
@@ -13,12 +13,16 @@ end
 
 # --------------------------------------------------------------------
 
+function simulator_init(state::State, sim::Simulator)
+    foreach(hook -> hook_init!(hook, state, sim), sim.hooks)
+end
+
 function update!(state::State, backend::Backend, sim::Simulator)
     backend_update!(state, backend, sim)
     state.previous, state.current = state.current, state.previous
     state.t    += sim.wave.dt
     state.iter += 1
-    foreach(hook -> hook_update!(hook, state, sim), sim.hooks)
+    simulator_init(state, sim)
 end
 
 function simulate!(state::State, backend::Backend, sim::Simulator)

--- a/src/simulator.jl
+++ b/src/simulator.jl
@@ -22,11 +22,11 @@ function update!(state::State, backend::Backend, sim::Simulator)
     state.previous, state.current = state.current, state.previous
     state.t    += sim.wave.dt
     state.iter += 1
-    simulator_init(state, sim)
+    foreach(hook -> hook_update!(hook, state, sim), sim.hooks)
 end
 
 function simulate!(state::State, backend::Backend, sim::Simulator)
-    foreach(hook -> hook_init!(hook, state, sim), sim.hooks)
+    simulator_init(state, sim)
     for _ in 1:sim.maxiter
         update!(state, backend, sim)
     end


### PR DESCRIPTION
In the package I'm working on which uses `WaveSimulator.jl`, I plan to run a simulation for an indefinite amount of time. Thus, when stepping the simulation via `update!` instead of `simulate!`, the hooks are never initialized, and so will throw an `access to undefined resource` exception on the first call. This PR adds a simple, single function (`simulator_init`) which does that, without the user having to manually initialize the hooks.

I know it's just a single line function, but it's much simpler/prettier to call from a user's end, and offers a place to put any other future initialization code that might be needed.

Let me what you think!