### PR TITLE
Some 0.7 fixes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,8 @@ ComputationalResources
 TiledIteration
 ProgressMeter
 ValueHistories
+ImageCore
+Distributions
+MappedArrays
+Colors
+FixedPointNumbers

--- a/REQUIRE
+++ b/REQUIRE
@@ -8,3 +8,5 @@ Distributions
 MappedArrays
 Colors
 FixedPointNumbers
+CUDAnative
+CUDAdrv

--- a/src/backends/cuda.jl
+++ b/src/backends/cuda.jl
@@ -28,7 +28,7 @@ function backend_update!(state::BoxState{2,T}, backend::CUDABackend, sim) where 
     yblocks = ceil(Int, h / threads[2])
     xblocks = ceil(Int, w / threads[1])
     # shmem = 2 * prod(threads.+2) * sizeof(T)
-    @cuda ((xblocks,yblocks),threads) cuda_kernel!(
+    @cuda blocks=(xblocks,yblocks) threads=threads cuda_kernel!(
         state.previous, state.current, state.q,
         sim.wave.λ,
         state.box.γ)
@@ -72,7 +72,7 @@ function backend_update!(state::BoxState{3,T}, backend::CUDABackend, sim) where 
     xblocks = ceil(Int, w / threads[1])
     zblocks = ceil(Int, v / threads[3])
     #shmem = Int(2 * prod(threads.+2) * sizeof(T))
-    @cuda ((xblocks,yblocks,zblocks),threads) cuda_kernel!(
+    @cuda blocks=(xblocks,yblocks,zblocks) threads=threads cuda_kernel!(
         state.previous, state.current, state.q,
         sim.wave.λ,
         state.box.γ)


### PR DESCRIPTION
This gets WaveSimulator.jl loading and running (on the CPU at least) on Julia release-0.7. I'm not really sure if my `@cuda` changes are correct, as I can't test them locally.